### PR TITLE
fix: tag rest controller

### DIFF
--- a/Resources/config/controllers.yml
+++ b/Resources/config/controllers.yml
@@ -16,3 +16,5 @@ services:
         class: '%pim_custom_entity.rest_controller.class%'
         arguments:
             - '@pim_custom_entity.configuration.registry'
+        tags:
+            - { name: controller.service_arguments }


### PR DESCRIPTION
Fix this exception : Uncaught PHP Exception InvalidArgumentException: "The controller for URI "/reference-data/rest" is not callable: Controller "pim_custom_entity.rest_controller" cannot be fetched from the container because it is private.